### PR TITLE
Fall back to MathText when LaTeX is not installed on the system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.gz
 *.xz
 *.DS_Store
+*.so
 /build/
 /src/starfit.egg-info
 __pycache__

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ StarFit can match combined abundances of multiple models. For single stars and c
 # Installation
 Tested with Python 3.10
 
+Optional: A working LaTeX installation and dvipng is required to create plots with LaTeX labels (ideal for publication). Otherwise, Matplotlib's default MathText is used, which may not render all symbols correctly.
+
 ## From PyPI (recommended)
 ```
 pip install starfit

--- a/src/starfit/starplot.py
+++ b/src/starfit/starplot.py
@@ -1,10 +1,19 @@
 """Various plotting routines"""
 
+from distutils.spawn import find_executable
 from itertools import cycle
 
 import matplotlib as mpl
 
-mpl.rc("text", usetex=True)
+if find_executable("latex"):
+    mpl.rc("text", usetex=True)
+else:
+    print(
+        "\nWarning: LaTeX installation not found. Reverting to use of 'mathtext' for plots.\n"
+    )
+    mpl.rc("font", family="serif")
+    mpl.rc("font", serif=["DejaVu Serif", "Computer Modern Roman"])
+    mpl.rc("mathtext", fontset="cm")
 
 import colorsys
 
@@ -103,7 +112,7 @@ def abuplot(
         ax.text(
             0.01,
             0.01,
-            r"\copyright\,www.StarFit.org",
+            r"$\copyright$ www.StarFit.org",
             size="x-small",
             horizontalalignment="left",
             verticalalignment="bottom",
@@ -155,7 +164,7 @@ def abuplot(
 
         if not nomix:
             texlabels += [
-                r"${}\,\mathrm{{M}}_\odot$, ${}\,\mathrm{{B}}$, \,$\log(f_\mathrm{{mix}})={}$".format(
+                r"${} \mathrm{{M}}_\odot$, ${} \mathrm{{B}}$, $\log(f_\mathrm{{mix}})={}$".format(
                     mass_string(fielddata[index]["mass"]),
                     round(fielddata[index]["energy"], 2),
                     round(fielddata[index]["mixing"], 4),
@@ -163,7 +172,7 @@ def abuplot(
             ]
         else:
             texlabels += [
-                r"${}\,\mathrm{{M}}_\odot$, ${}\,\mathrm{{B}}$, \,$\mathrm{{no\ mixing}}$".format(
+                r"${} \mathrm{{M}}_\odot$, ${} \mathrm{{B}}$, $\mathrm{{no\ mixing}}$".format(
                     mass_string(fielddata[index]["mass"]),
                     round(fielddata[index]["energy"], 2),
                 )


### PR DESCRIPTION
Currently, users are required to have a working LaTeX installation to make plots. This PR adds a check to see if it is installed. If it is not available, MathText is used instead.