### PR TITLE
Only publish to Test PyPI if "test" is in the tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish to PyPI
 
 on:
+  push:
   release:
     types: [published]
 
@@ -11,38 +12,41 @@ jobs:
     steps:
         - uses: actions/checkout@master
 
-        - name: Download data files
-          run: |
-            ./download-data.sh
+        # - name: Download data files
+        #   run: |
+        #     ./download-data.sh
 
-        - name: Set up Python
-          uses: actions/setup-python@v3
-          with:
-            python-version: "3.10"
+        # - name: Set up Python
+        #   uses: actions/setup-python@v3
+        #   with:
+        #     python-version: "3.10"
 
-        - name: Install pypa/build
-          run: >-
-            python -m
-            pip install
-            build
-            --user
+        # - name: Install pypa/build
+        #   run: >-
+        #     python -m
+        #     pip install
+        #     build
+        #     --user
 
-        - name: Build a source tarball
-          run: >-
-            python -m
-            build
-            --sdist
-            --outdir dist/
+        # - name: Build a source tarball
+        #   run: >-
+        #     python -m
+        #     build
+        #     --sdist
+        #     --outdir dist/
 
-        - name: Publish distribution to Test PyPI
-          uses: pypa/gh-action-pypi-publish@release/v1
-          if: startsWith(github.ref, 'refs/tags')
-          with:
-            password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-            repository_url: https://test.pypi.org/legacy/
+        - name: debug
+          run: echo ${{ github.ref }}
 
-        - name: Publish distribution to PyPI
-          if: startsWith(github.ref, 'refs/tags')
-          uses: pypa/gh-action-pypi-publish@release/v1
-          with:
-            password: ${{ secrets.PYPI_API_TOKEN }}
+        # - name: Publish distribution to Test PyPI
+        #   uses: pypa/gh-action-pypi-publish@release/v1
+        #   if: startsWith(github.ref, 'refs/tags')
+        #   with:
+        #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        #     repository_url: https://test.pypi.org/legacy/
+
+        # - name: Publish distribution to PyPI
+        #   if: startsWith(github.ref, 'refs/tags')
+        #   uses: pypa/gh-action-pypi-publish@release/v1
+        #   with:
+        #     password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,13 +36,13 @@ jobs:
 
         - name: Publish distribution to Test PyPI
           uses: pypa/gh-action-pypi-publish@release/v1
-          if: ${{ startsWith(github.ref, 'refs/tags') && endsWith(github.ref, '-test') }}
+          if: ${{ startsWith(github.ref, 'refs/tags') && contains(github.ref, '.dev') }}
           with:
             password: ${{ secrets.TEST_PYPI_API_TOKEN }}
             repository_url: https://test.pypi.org/legacy/
 
         - name: Publish distribution to PyPI
-          if: ${{ startsWith(github.ref, 'refs/tags') && !endsWith(github.ref, '-test') }}
+          if: ${{ startsWith(github.ref, 'refs/tags') && !contains(github.ref, '.dev') }}
           uses: pypa/gh-action-pypi-publish@release/v1
           with:
             password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         #     --outdir dist/
 
         - name: debug
-          run: echo ${{ github.ref }}
+          run: echo ${{ endsWith(github.ref, '-test') }}
 
         # - name: Publish distribution to Test PyPI
         #   uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         #     --outdir dist/
 
         - name: debug
-          run: echo ${{ endsWith(github.ref, '-test') }}
+          run: echo ${{ !endsWith(github.ref, '-test') }}
 
         # - name: Publish distribution to Test PyPI
         #   uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,6 @@
 name: Publish to PyPI
 
 on:
-  push:
   release:
     types: [published]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,41 +12,38 @@ jobs:
     steps:
         - uses: actions/checkout@master
 
-        # - name: Download data files
-        #   run: |
-        #     ./download-data.sh
+        - name: Download data files
+          run: |
+            ./download-data.sh
 
-        # - name: Set up Python
-        #   uses: actions/setup-python@v3
-        #   with:
-        #     python-version: "3.10"
+        - name: Set up Python
+          uses: actions/setup-python@v3
+          with:
+            python-version: "3.10"
 
-        # - name: Install pypa/build
-        #   run: >-
-        #     python -m
-        #     pip install
-        #     build
-        #     --user
+        - name: Install pypa/build
+          run: >-
+            python -m
+            pip install
+            build
+            --user
 
-        # - name: Build a source tarball
-        #   run: >-
-        #     python -m
-        #     build
-        #     --sdist
-        #     --outdir dist/
+        - name: Build a source tarball
+          run: >-
+            python -m
+            build
+            --sdist
+            --outdir dist/
 
-        - name: debug
-          run: echo ${{ !endsWith(github.ref, '-test') }}
+        - name: Publish distribution to Test PyPI
+          uses: pypa/gh-action-pypi-publish@release/v1
+          if: ${{ startsWith(github.ref, 'refs/tags') && endsWith(github.ref, '-test') }}
+          with:
+            password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+            repository_url: https://test.pypi.org/legacy/
 
-        # - name: Publish distribution to Test PyPI
-        #   uses: pypa/gh-action-pypi-publish@release/v1
-        #   if: startsWith(github.ref, 'refs/tags')
-        #   with:
-        #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        #     repository_url: https://test.pypi.org/legacy/
-
-        # - name: Publish distribution to PyPI
-        #   if: startsWith(github.ref, 'refs/tags')
-        #   uses: pypa/gh-action-pypi-publish@release/v1
-        #   with:
-        #     password: ${{ secrets.PYPI_API_TOKEN }}
+        - name: Publish distribution to PyPI
+          if: ${{ startsWith(github.ref, 'refs/tags') && !endsWith(github.ref, '-test') }}
+          uses: pypa/gh-action-pypi-publish@release/v1
+          with:
+            password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This allows the publishing functionality to be tested without publishing to real PyPI. If `.dev` is in the tag, then it is published to test.pypi only. If `.dev` is not in the tag, then it is published to real pypi only. See this [example](https://github.com/conradtchan/starfit/releases/tag/0.0.0.dev).