### PR TITLE
only include fitness function by providing fitness.pyf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,22 +7,26 @@ flags = ["-fPIC", "-Ofast", "-g", "-funroll-loops", "-fno-second-underscore", "-
 cwd = os.getcwd()
 starfit_src = os.path.join(cwd, "src/starfit")
 
+
+fit_sources = [
+    os.path.join(starfit_src, "fitness", x)
+    for x in [
+        "fitness.pyf",
+        "type_def.f90",
+        "powell.f90",
+        "norm.f90",
+        "mleqs.f90",
+        "star_data.f90",
+        "abu_data.f90",
+        "solver.f90",
+    ]
+]
+# to skip fitness.pyf if need be
+fit_sources = [x for x in fit_sources if os.path.isfile(x)]
+
 module_solver = Extension(
     "starfit.fitness._solver",
-    sources=(
-        [
-            os.path.join(starfit_src, "fitness", x)
-            for x in [
-                "type_def.f90",
-                "powell.f90",
-                "norm.f90",
-                "mleqs.f90",
-                "star_data.f90",
-                "abu_data.f90",
-                "solver.f90",
-            ]
-        ]
-    ),
+    sources=fit_sources,
     extra_f90_compile_args=flags,
     f2py_options=[
         "--f2cmap",

--- a/src/starfit/fitness/.gitignore
+++ b/src/starfit/fitness/.gitignore
@@ -1,0 +1,4 @@
+fortranobject.h
+fortranobject.c
+_solvermodule.c
+_solver-f2pywrappers2.f90

--- a/src/starfit/fitness/fitness.pyf
+++ b/src/starfit/fitness/fitness.pyf
@@ -1,0 +1,30 @@
+!    -*- f90 -*-
+! Note: the context of this file is case sensitive.
+
+python module _solver ! in
+    interface  ! in :_solver
+        module solver ! in :_solver:solver.f90
+            use type_def, only: real64,int64
+            subroutine fitness(f,c,obs,err,cov,abu,nel,ncov,nstar,nsol,ls,icdf) ! in :_solver:solver.f90:solver
+                use star_data, only: set_star_data,abu_covariance
+                use type_def, only: real64,int64
+                real(kind=real64) dimension(nsol),intent(out),depend(nsol) :: f
+                real(kind=real64) dimension(nsol,nstar),intent(in,out) :: c
+                real(kind=real64) dimension(nel),intent(in) :: obs
+                real(kind=real64) dimension(nel),intent(in),depend(nel) :: err
+                real(kind=real64) dimension(nel,ncov),intent(in),depend(nel) :: cov
+                real(kind=real64) dimension(nsol,nstar,nel),intent(in),depend(nstar,nsol,nel) :: abu
+                integer(kind=int64), optional,intent(in),check(shape(obs, 0) == nel),depend(obs) :: nel=shape(obs, 0)
+                integer(kind=int64), optional,intent(in),check(shape(cov, 1) == ncov),depend(cov) :: ncov=shape(cov, 1)
+                integer(kind=int64), optional,intent(in),check(shape(c, 1) == nstar),depend(c) :: nstar=shape(c, 1)
+                integer(kind=int64), optional,intent(in),check(shape(c, 0) == nsol),depend(c) :: nsol=shape(c, 0)
+                integer(kind=int64) intent(in) :: ls
+                integer(kind=int64) intent(in) :: icdf
+            end subroutine fitness
+        end module solver
+    end interface
+end python module _solver
+
+! This file was auto-generated with f2py (version:1.23.4).
+! See:
+! https://web.archive.org/web/20140822061353/http://cens.ioc.ee/projects/f2py2e

--- a/src/starfit/fitness/make_pyf.txt
+++ b/src/starfit/fitness/make_pyf.txt
@@ -1,0 +1,3 @@
+f2py -m _solver -h fitness.pyf --f2cmap .f2py_f2cmap *.f90 only: fitness :
+
+edit fitness.pyf to remove all but the fitness function


### PR DESCRIPTION
The hope is that modules can live by themselves w/o wrapping an allowing full Fortran functionality support.

The background is that whereas `f2py` allows selectively wrapping of subroutines, `numpy.setuptools` does not expose this functionality at its API.

The downside is the requirement for manual adjustment of the `*.pyf` file if the interface changes.