### PR TITLE
Fix omp build flags

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,9 +33,9 @@ inc_np = include_directories(incdir_numpy, incdir_f2py)
 
 if meson.get_compiler('c').get_id() == 'clang'
   # Meson's OpenMP dependency does not work on mac yet
-  omp = declare_dependency(compile_args: ['-Xpreprocessor', '-fopenmp'], link_args: ['-lgomp'])
+  omp = declare_dependency(compile_args: ['-fopenmp'], link_args: ['-fopenmp'])
 else
-  omp = dependency('openmp')
+omp = dependency('openmp')
 endif
 
 subdir('src/starfit')

--- a/src/starfit/fitness/meson.build
+++ b/src/starfit/fitness/meson.build
@@ -46,7 +46,7 @@ py3.extension_module(module_name,
     incdir_f2py+'/fortranobject.c',
     link_with: fortran_library,
     include_directories: inc_np,
-    dependencies: [py3.dependency(), omp],
+    dependencies: py3.dependency(),
     install: true,
     subdir: path,
     )


### PR DESCRIPTION
The `-Xpreprocessor` flag isn't used for gfortran and causes OpenMP code to not build properly